### PR TITLE
Fix viewport warnings on safari

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -9,7 +9,7 @@
 	<% } %>
 	<meta charset="utf-8">
 	<title>Netlify Identity Widget</title>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimal-ui">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 	<meta name="description" content="preact-boilerplate">
 	<meta name="msapplication-TileColor" content="#673ab8">
 	<meta name="msapplication-TileImage" content="./assets/icons/mstile-150x150.png">


### PR DESCRIPTION
Fixes warnings on safari regarding `Viewport argument key "minimal-ui" not recognized and ignored.`