### PR TITLE
Fix race condition on currentUser call

### DIFF
--- a/src/netlify-identity.js
+++ b/src/netlify-identity.js
@@ -35,9 +35,6 @@ const netlifyIdentity = {
     store.closeModal();
   },
   currentUser: () => {
-    if (!store.gotrue) {
-      store.openModal("login");
-    }
     return store.gotrue && store.gotrue.currentUser();
   },
   logout: () => {


### PR DESCRIPTION
This would trigger a bad state if gotrue had not been initialized before currentUser was first called