### PR TITLE
removes the relative or

### DIFF
--- a/src/components/modal.css
+++ b/src/components/modal.css
@@ -392,7 +392,6 @@
 }
 
 .hr::before {
-  content: "or";
   position: relative;
   display: inline-block;
   font-size: 12px;

--- a/src/components/modal.css
+++ b/src/components/modal.css
@@ -10,7 +10,8 @@
   --providerAltColorGitLab: #b03320;
   --providerColorBitbucket: #205081;
   --providerAltColorBitbucket: #14314f;
-  --fontFamily: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  --fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   --basePadding: 32px;
 }
 
@@ -389,9 +390,11 @@
   border-top: 2px solid #e9ebeb;
   margin: var(--basePadding) 0 -1px;
   text-align: center;
+  overflow: visible;
 }
 
 .hr::before {
+  content: "or";
   position: relative;
   display: inline-block;
   font-size: 12px;
@@ -401,7 +404,7 @@
   background-color: #fff;
   color: var(--baseColor);
   padding: 4px;
-  top: -13px;
+  top: -11px;
 }
 
 .btnProvider {


### PR DESCRIPTION
# What is this?

While testing out the identity widget I noticed that the *or* is not actually showing. 

My feeling is that it is implied, so I removed it in this PR.

### Before
![screenshot 2017-09-25 16 29 45](https://user-images.githubusercontent.com/5713670/30841050-516f52a0-a22f-11e7-9b9a-2a3a47e314f7.png)

### Before with padding increased greater than 4px
![screenshot 2017-09-25 16 26 19](https://user-images.githubusercontent.com/5713670/30841081-7328886c-a22f-11e7-8371-22d30ae94433.png)

### After
<img width="526" alt="screenshot 2017-09-25 20 23 35" src="https://user-images.githubusercontent.com/5713670/30841078-6ed00cd6-a22f-11e7-95df-6b0c1afec338.png">
