### PR TITLE
Set a cookie when not using cors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netlify-identity-widget",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "releaseVersion": "v1",
   "description": "Netlify Identity widget for easy integration",
   "scripts": {
@@ -45,7 +45,7 @@
     "eslint-plugin-prettier": "^2.2.0",
     "eslint-plugin-react": "^7.0.0",
     "file-loader": "^0.11.1",
-    "gotrue-js": "^0.9.11",
+    "gotrue-js": "^0.9.12",
     "html-webpack-plugin": "^2.28.0",
     "json-loader": "^0.5.4",
     "mkdirp": "^0.5.1",

--- a/src/netlify-identity.js
+++ b/src/netlify-identity.js
@@ -79,13 +79,13 @@ function instantiateGotrue() {
       parts.push("/");
     }
     parts.push(".netlify/identity");
-    return new GoTrue({ APIUrl: parts.join("") });
+    return new GoTrue({ APIUrl: parts.join(""), setCookie: !isLocal });
   }
   if (isLocal) {
     return null;
   }
 
-  return new GoTrue();
+  return new GoTrue({ setCookie: !isLocal });
 }
 
 let root;

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -11,7 +11,7 @@ const CSS_MAPS = ENV !== "production";
 module.exports = {
   context: path.resolve(__dirname, "src"),
   entry: {
-    "netlify-identity-widget": "./index.js",
+    "netlify-identity-widget": "./index.js"
   },
 
   output: {


### PR DESCRIPTION
This allows the widget to be used with netlify's role based access control