### PR TITLE
Clear saving state when logout is called without a user

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -165,15 +165,15 @@ class App extends Component {
           {this.renderBody()}
           {this.renderProviders()}
           {!store.user &&
-          page.link &&
-          store.gotrue && (
-            <button
-              onclick={pageLinkHandler}
-              className="btnLink forgotPasswordLink"
-            >
-              {page.link_text}
-            </button>
-          )}
+            page.link &&
+            store.gotrue && (
+              <button
+                onclick={pageLinkHandler}
+                className="btnLink forgotPasswordLink"
+              >
+                {page.link_text}
+              </button>
+            )}
         </Modal>
       </div>
     );

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -125,19 +125,21 @@ store.signup = action(function signup(name, email, password) {
 
 store.logout = action(function logout() {
   store.startAction();
-  return (
-    store.user &&
-    store.user
-      .logout()
-      .then(
-        action(() => {
-          store.user = null;
-          store.modal.page = "login";
-          store.saving = false;
-        })
-      )
-      .catch(store.setError)
-  );
+  return store.user
+    ? store.user
+        .logout()
+        .then(
+          action(() => {
+            store.user = null;
+            store.modal.page = "login";
+            store.saving = false;
+          })
+        )
+        .catch(store.setError)
+    : action(() => {
+        store.modal.page = "login";
+        store.saving = false;
+      });
 });
 
 store.updatePassword = action(function updatePassword(password) {


### PR DESCRIPTION
If a consumer calls logout without a user, the widget becomes stuck in the saving state.  This clears it.