### PR TITLE
Update gotrue and bump the widget version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netlify-identity-widget",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "releaseVersion": "v1",
   "description": "Netlify Identity widget for easy integration",
   "scripts": {
@@ -46,7 +46,7 @@
     "eslint-plugin-prettier": "^2.2.0",
     "eslint-plugin-react": "^7.0.0",
     "file-loader": "^0.11.1",
-    "gotrue-js": "^0.9.14",
+    "gotrue-js": "^0.9.15",
     "html-webpack-plugin": "^2.28.0",
     "json-loader": "^0.5.4",
     "mkdirp": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2694,9 +2694,9 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-gotrue-js@^0.9.14:
-  version "0.9.14"
-  resolved "https://registry.yarnpkg.com/gotrue-js/-/gotrue-js-0.9.14.tgz#1cc85210a0ede5ba9e30932bd44df37146a1ee48"
+gotrue-js@^0.9.15:
+  version "0.9.15"
+  resolved "https://registry.yarnpkg.com/gotrue-js/-/gotrue-js-0.9.15.tgz#ccddda083ba8fc75572c7e7817556be2b09b3ab4"
   dependencies:
     micro-api-client "^3.2.0"
 


### PR DESCRIPTION
Should fix a race condition when several places calls `user.jwt()` at the same time in apps consuming the widget.