### PR TITLE
Add APIUrl option to module API

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ const netlifyIdentity = require("netlify-identity-widget");
 
 netlifyIdentity.init({
   container: "#netlify-modal" // defaults to document.body,
-  APIUrl: "https://some-identity-instance.example.com" // Set an absolute URL for the identity endpoint
 });
 
 netlifyIdentity.open(); // open the modal
@@ -120,6 +119,23 @@ netlifyIdentity.logout();
 // sync between your state and the widgets state.
 netlifyIdentity.gotrue;
 ```
+
+#### `netlifyIdentity.init([opts])`
+
+You can pass an optional `opts` object to configure the widget when using the
+module api. Options include:
+
+```js
+{
+  container: "#some-query-selector"; // container to attach to
+  APIUrl: "https://www.example.com/.netlify/functions/identity"; // Absolute url to endpoint.  ONLY USE IN SPECIAL CASES!
+}
+```
+
+Generally avoid setting the `APIUrl`. You should only set this when your app is
+served from a domain that differs from where the identity endpoint is served.
+This is common for Cordova or Electron apps where you host from localhost or a
+file.
 
 ## Localhost
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ const netlifyIdentity = require("netlify-identity-widget");
 
 netlifyIdentity.init({
   container: "#netlify-modal" // defaults to document.body,
+  APIUrl: "https://some-identity-instance.example.com" // Set an absolute URL for the identity endpoint
 });
 
 netlifyIdentity.open(); // open the modal

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -5,6 +5,7 @@ import App from './App';
 import registerServiceWorker from './registerServiceWorker';
 import netlifyIdentity from 'netlify-identity-widget';
 
+window.netlifyIdentity = netlifyIdentity
 // You must run this once before trying to interact with the widget
 netlifyIdentity.init()
 

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -156,7 +156,7 @@ class App extends Component {
           showHeader={showHeader}
           showSignup={showSignup}
           devSettings={!store.gotrue}
-          loading={store.gotrue && !store.settings}
+          loading={!store.error && store.gotrue && !store.settings}
           isOpen={store.modal.isOpen}
           onPage={this.handlePage}
           onClose={this.handleClose}

--- a/src/netlify-identity.js
+++ b/src/netlify-identity.js
@@ -49,7 +49,8 @@ const netlifyIdentity = {
   },
   init: options => {
     init(options);
-  }
+  },
+  store
 };
 
 let queuedIframeStyle = null;

--- a/src/netlify-identity.js
+++ b/src/netlify-identity.js
@@ -71,9 +71,12 @@ const localHosts = {
   "0.0.0.0": true
 };
 
-function instantiateGotrue() {
+function instantiateGotrue(APIUrl) {
   const isLocal = localHosts[document.location.host.split(":").shift()];
   const siteURL = isLocal && localStorage.getItem("netlifySiteURL");
+  if (APIUrl) {
+    return new GoTrue({ APIUrl, setCookie: !isLocal });
+  }
   if (isLocal && siteURL) {
     const parts = [siteURL];
     if (!siteURL.match(/\/$/)) {
@@ -175,8 +178,8 @@ function runRoutes() {
   }
 }
 
-function init(options) {
-  options = options || {};
+function init(options = {}) {
+  const { APIUrl } = options;
   const controlEls = document.querySelectorAll(
     "[data-netlify-identity-menu],[data-netlify-identity-button]"
   );
@@ -195,8 +198,8 @@ function init(options) {
     );
   });
 
-  store.init(instantiateGotrue());
-  if (options.hasOwnProperty("logo")) store.modal.logo = options.logo;
+  store.init(instantiateGotrue(APIUrl));
+  if (options.logo) store.modal.logo = options.logo;
   iframe = document.createElement("iframe");
   iframe.id = "netlify-identity-widget";
   iframe.onload = () => {

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -56,8 +56,9 @@ store.loadSettings = action(function loadSettings() {
     .then(action(settings => (store.settings = settings)))
     .catch(
       action(err => {
-        console.error("failed to load settings %o", err);
-        store.error = err;
+        store.error = new Error(
+          `Failed to load settings from ${store.gotrue.api.apiURL}`
+        );
       })
     );
 });


### PR DESCRIPTION
Add option to allow the definition of an APIUrl for when you want to use a absolute URL from a Cordova app or electron app.