### PR TITLE
Fix adblock pro blocking

### DIFF
--- a/src/netlify-identity.js
+++ b/src/netlify-identity.js
@@ -114,7 +114,7 @@ observe(store.modal, "isOpen", () => {
   }
   setStyle(iframe, {
     ...iframeStyle,
-    display: store.modal.isOpen ? "block" : "none"
+    display: store.modal.isOpen ? "block !important" : "none"
   });
   if (store.modal.isOpen) {
     trigger("open", store.modal.page);


### PR DESCRIPTION
It seems adblock pro started setting `display: none` on all iframes with `src="about:blank"` :/

This is a quick fix for the identity widget