### PR TITLE
Fix source maps on UMD

### DIFF
--- a/webpack.umd.config.babel.js
+++ b/webpack.umd.config.babel.js
@@ -14,7 +14,7 @@ const umdConfig = Object.assign({}, baseConfig, {
     libraryTarget: "umd",
     libraryExport: "default"
   },
-  devtool: "hidden-source-map"
+  devtool: "source-map"
 });
 
 umdConfig.plugins.splice(2, 1); // Remove html plugin


### PR DESCRIPTION
We had hidden source maps preventing devtools from picking up sourcemaps.