### PR TITLE
Improve hash cleaning regex

### DIFF
--- a/src/netlify-identity.js
+++ b/src/netlify-identity.js
@@ -149,7 +149,7 @@ const errorRoute = /error=access_denied&error_description=403/;
 const accessTokenRoute = /access_token=/;
 
 function runRoutes() {
-  const hash = (document.location.hash || "").replace(/^#/, "");
+  const hash = (document.location.hash || "").replace(/^#\\?/, "");
   if (!hash) {
     return;
   }

--- a/src/netlify-identity.js
+++ b/src/netlify-identity.js
@@ -149,7 +149,7 @@ const errorRoute = /error=access_denied&error_description=403/;
 const accessTokenRoute = /access_token=/;
 
 function runRoutes() {
-  const hash = (document.location.hash || "").replace(/^#\\?/, "");
+  const hash = (document.location.hash || "").replace(/^#\/?/, "");
   if (!hash) {
     return;
   }


### PR DESCRIPTION
This guards against an observed scenario where netlify-cms (and other SPA's using hash routing) might insert a `\` into the hash on page load.