### PR TITLE
Modal close button: multiplication "✕" instead of "x"

### DIFF
--- a/src/components/modal.css
+++ b/src/components/modal.css
@@ -251,7 +251,7 @@
 }
 
 .btnClose::before {
-  content: "×";
+  content: "✕";
   font-size: 20px;
   line-height: 22px;
 }


### PR DESCRIPTION
This corrects a small visual glitch where the "x" is not centred inside the circular button. "✕" is slightly larger and easier to see, as well as being centred it so it looks a little more polished.