### PR TITLE
Clarify local Site URL popup.

### DIFF
--- a/src/components/forms/siteurl.js
+++ b/src/components/forms/siteurl.js
@@ -22,7 +22,7 @@ export default class SiteURLForm extends Component {
       <form onsubmit={this.handleSiteURL} className="form">
         <div className="flashMessage">
           {
-            "Looks like you're running a local server. Please let us know the URL of your site."
+            "Looks like you're running a local server. Please let us know the URL of your Netlify site."
           }
         </div>
         <div className="formGroup">


### PR DESCRIPTION
This seems to cause quite a bit of confusion for some people on whether to enter their local server URL or the live Netlify site URL. This wording might need to be changed a bit, though, any thoughts?

> @rafaelconde from https://github.com/netlify/netlify-identity-widget/pull/31:
> Maybe add a documentation link somewhere? I am still not sure, but it would be nice to give some guidance to people who have no idea what it might mean, your Netlify site URL.

Related to #40.