### PR TITLE
Support async loading

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,10 @@ if (typeof exports !== undefined) {
 if (typeof window !== undefined) {
   window.netlifyIdentity = netlifyIdentity;
 }
-
-document.addEventListener("DOMContentLoaded", () => {
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", () => {
+    netlifyIdentity.init();
+  });
+} else {
   netlifyIdentity.init();
-});
+}


### PR DESCRIPTION
Fixes widget not initializing if loaded async or after the `DOMContentLoaded` event fires. That event fires when `readystate` changes from initial state `loading` to `interactive`, so we should only use the listener if the current state is `loading`.

Reference: https://github.com/AustinGreen/gatsby-starter-netlify-cms/issues/55#issuecomment-370480787