### PR TITLE
Make Close Button bigger and centered

### DIFF
--- a/src/components/modal.css
+++ b/src/components/modal.css
@@ -252,8 +252,8 @@
 
 .btnClose::before {
   content: "×";
-  font-size: 20px;
-  line-height: 22px;
+  font-size: 25px;
+  line-height: 9px;
 }
 
 .btnClose:hover,


### PR DESCRIPTION
Alternate option for #121 

Making the `X` in the widget close button a bit bigger and centered with the hover circular outline.
The reason I opted to keep `x` as opposed to `✕` is to make it more balanced with the rest of the typography.