### PR TITLE
Allow display of SAML provider button

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -132,9 +132,13 @@ class App extends Component {
       return null;
     }
 
-    const providers = ["Google", "GitHub", "GitLab", "BitBucket"].filter(
-      p => store.settings.external[p.toLowerCase()]
-    );
+    const providers = [
+      "Google",
+      "GitHub",
+      "GitLab",
+      "BitBucket",
+      "SAML"
+    ].filter(p => store.settings.external[p.toLowerCase()]);
 
     return providers.length ? (
       <Providers providers={providers} onLogin={this.handleExternalLogin} />

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -141,7 +141,11 @@ class App extends Component {
     ].filter(p => store.settings.external[p.toLowerCase()]);
 
     return providers.length ? (
-      <Providers providers={providers} onLogin={this.handleExternalLogin} />
+      <Providers
+        providers={providers}
+        labels={store.settings.external_labels || {}}
+        onLogin={this.handleExternalLogin}
+      />
     ) : null;
   }
 

--- a/src/components/forms/providers.js
+++ b/src/components/forms/providers.js
@@ -7,20 +7,28 @@ class Provider extends Component {
   };
 
   render() {
-    const { provider } = this.props;
+    const { provider, label } = this.props;
 
     return (
       <button
         onClick={this.handleLogin}
         className={`provider${provider} btn btnProvider`}
       >
-        Continue with {provider}
+        Continue with {label}
       </button>
     );
   }
 }
 
 export default class Providers extends Component {
+  getLabel(p) {
+    const pId = p.toLowerCase();
+    if (pId in this.props.labels) {
+      return this.props.labels[pId];
+    }
+    return p;
+  }
+
   render() {
     const { providers, onLogin } = this.props;
 
@@ -28,7 +36,12 @@ export default class Providers extends Component {
       <div className="providersGroup">
         <hr className="hr" />
         {providers.map(p => (
-          <Provider key={p} provider={p} onLogin={onLogin} />
+          <Provider
+            key={p}
+            provider={p}
+            label={this.getLabel(p)}
+            onLogin={onLogin}
+          />
         ))}
       </div>
     );


### PR DESCRIPTION
*I am currently hired by Netlify to develop SAML 2.0 support in GoTrue. See this PR for the backend implementation: https://github.com/netlify/gotrue/pull/181*

There is going to be a `external.saml` key in the GoTrue `/settings` route.
This PR is used to add support for redirecting to this provider.

The SAML provider will behave exactly like any other provider in terms of frontend code. A redirect is issued to `/authorize?provider=saml` and the site receives a redirect with either a token or an error.

Also, this PR adds support to override the name of the provider which is used in the button of the widget. GoTrue will add a new key `external_labels` which contains these overrides. For the time being overrides will only be available for the SAML provider.

Example of the updated `/settings` payload:

```json
{
    "external": {
        "bitbucket": false,
        "github": false,
        "gitlab": false,
        "google": false,
        "facebook": false,
        "email": false,
        "saml": true
    },
    "external_labels": {
        "saml": "G Suite"
    },
    "disable_signup": false,
    "autoconfirm": false
}
```