### PR TITLE
added refresh method from gotrue

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ netlifyIdentity.close();
 
 // Log out the user
 netlifyIdentity.logout();
+// refresh the user's JWT 
+// Note: this method returns a promise.
+netlifyIdentity.refresh().then((jwt)=>console.log(jwt))
 ```
 
 #### A note on script tag versioning
@@ -112,6 +115,10 @@ netlifyIdentity.close();
 
 // Log out the user
 netlifyIdentity.logout();
+
+// refresh the user's JWT 
+// Note: this method returns a promise.
+netlifyIdentity.refresh().then((jwt)=>console.log(jwt))
 
 // Access the underlying GoTrue JS client.
 // Note that doing things directly through the GoTrue client brings a risk of getting out of

--- a/src/netlify-identity.js
+++ b/src/netlify-identity.js
@@ -47,6 +47,12 @@ const netlifyIdentity = {
     }
     return store.gotrue;
   },
+  refresh(force) {
+    if (!store.gotrue) {
+      store.openModal("login");
+    }
+    return store.gotrue.currentUser().jwt(force);
+  },
   init: options => {
     init(options);
   },


### PR DESCRIPTION
This fixes https://github.com/netlify/netlify-identity-widget/issues/233 by adding a `.refresh()` method to netlify-identity-widget that is the equivalent of running `netlifyIdentity.gotrue.currentUser().jwt()` . This PR also includes an update to the README. 

![image](https://user-images.githubusercontent.com/23725114/80847190-b12ffe80-8bdc-11ea-9faf-6ed79e4a5654.png)


cc @jlengstorf 