### PR TITLE
`yarn dev` is used to run the development server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,10 @@ $ yarn build
 ```
 
 
-## Runing the server
+## Running the server
 
 ```sh
-$ yarn start
+$ yarn dev
 ```
 
 ## Pull Requests


### PR DESCRIPTION
`yarn start` doesn't exist.

Also fix a spelling mistake.