### PR TITLE
fix: prevent double initialization

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  semi: true,
+  singleQuote: false,
+  trailingComma: "none",
+  tabWidth: 2
+};

--- a/src/netlify-identity.js
+++ b/src/netlify-identity.js
@@ -9,7 +9,7 @@ import modalCSS from "./components/modal.css";
 
 const callbacks = {};
 function trigger(callback) {
-  const cbMap = callbacks[callback] || new Map();
+  const cbMap = callbacks[callback] || new Set();
   Array.from(cbMap.values()).forEach(cb => {
     cb.apply(cb, Array.prototype.slice.call(arguments, 1));
   });

--- a/src/netlify-identity.js
+++ b/src/netlify-identity.js
@@ -151,9 +151,14 @@ observe(store, "siteURL", () => {
   if (store.siteURL === null || store.siteURL === undefined) {
     localStorage.removeItem("netlifySiteURL");
   } else {
+    const currentURL = localStorage.getItem("netlifySiteURL");
+
+    // if nothing has changed, don’t do anything
+    if (currentURL === store.siteURL) return;
+
     localStorage.setItem("netlifySiteURL", store.siteURL);
+    store.init(instantiateGotrue(), true);
   }
-  store.init(instantiateGotrue(), true);
 });
 
 observe(store, "user", () => {

--- a/src/netlify-identity.js
+++ b/src/netlify-identity.js
@@ -94,23 +94,17 @@ const localHosts = {
 };
 
 function instantiateGotrue(APIUrl) {
-  const isLocal = localHosts[document.location.host.split(":").shift()];
-  const siteURL = isLocal && localStorage.getItem("netlifySiteURL");
+  const isLocal = localHosts[document.location.hostname];
   if (APIUrl) {
     return new GoTrue({ APIUrl, setCookie: !isLocal });
   }
-  if (isLocal && siteURL) {
-    const parts = [siteURL];
-    if (!siteURL.match(/\/$/)) {
-      parts.push("/");
-    }
-    parts.push(".netlify/identity");
-    store.setIsLocal(isLocal);
-    store.setSiteURL(siteURL);
-    return new GoTrue({ APIUrl: parts.join(""), setCookie: !isLocal });
-  }
   if (isLocal) {
     store.setIsLocal(isLocal);
+    const siteURL = localStorage.getItem("netlifySiteURL");
+    if (siteURL) {
+      // setting a siteURL will invoke instantiateGotrue again with the relevant APIUrl
+      store.setSiteURL(siteURL);
+    }
     return null;
   }
 
@@ -151,14 +145,15 @@ observe(store, "siteURL", () => {
   if (store.siteURL === null || store.siteURL === undefined) {
     localStorage.removeItem("netlifySiteURL");
   } else {
-    const currentURL = localStorage.getItem("netlifySiteURL");
-
-    // if nothing has changed, don’t do anything
-    if (currentURL === store.siteURL) return;
-
     localStorage.setItem("netlifySiteURL", store.siteURL);
-    store.init(instantiateGotrue(), true);
   }
+
+  let apiUrl;
+  if (store.siteURL) {
+    const siteUrl = store.siteURL.replace(/\/$/, "");
+    apiUrl = `${siteUrl}/.netlify/identity`;
+  }
+  store.init(instantiateGotrue(apiUrl), true);
 });
 
 observe(store, "user", () => {

--- a/src/netlify-identity.js
+++ b/src/netlify-identity.js
@@ -9,7 +9,7 @@ import modalCSS from "./components/modal.css";
 
 const callbacks = {};
 function trigger(callback) {
-  const cbMap = callbacks[callback] || new Set();
+  const cbMap = callbacks[callback] || new Map();
   Array.from(cbMap.values()).forEach(cb => {
     cb.apply(cb, Array.prototype.slice.call(arguments, 1));
   });


### PR DESCRIPTION
(NOTE: don’t merge this until #283 goes in)

when setting the URL, the initialize function needs to be called or else the widget gets stuck. however, when no change is required, the init function was being called twice anyways, which caused some undesirable behavior

this adds a check to fix that