### PR TITLE
Changes Sign Up form type to name instead of email

### DIFF
--- a/src/components/forms/user.js
+++ b/src/components/forms/user.js
@@ -39,7 +39,7 @@ export default class UserForm extends Component {
                 name="name"
                 value={name}
                 placeholder={
-                  namePlaceholder ? namePlaceholder : t("form_email_label")
+                  namePlaceholder ? namePlaceholder : t("form_name_label")
                 }
                 autocapitalize="off"
                 required


### PR DESCRIPTION
Form type was set to email so the form placeholder asked for email when it needed name.

Before:
<img width="769" alt="Screen Shot 2020-07-05 at 4 38 05 PM" src="https://user-images.githubusercontent.com/3611928/86542010-c4fb2800-bedf-11ea-83a3-b731baf40280.png">

After:

<img width="488" alt="Screen Shot 2020-07-05 at 4 53 46 PM" src="https://user-images.githubusercontent.com/3611928/86542080-2e7b3680-bee0-11ea-81f3-95249f20f938.png">

closes #285 