### PR TITLE
chore(deps): remove unused raw-loader dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "postcss-nested": "^3.0.0",
     "preact": "^8.1.0",
     "prettier": "^1.10.2",
-    "raw-loader": "^0.5.1",
     "rimraf": "^3.0.0",
     "source-map-loader": "^0.2.1",
     "url-loader": "^0.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7501,11 +7501,6 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-raw-loader@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-0.5.1.tgz#0c3d0beaed8a01c966d9787bf778281252a979aa"
-  integrity sha1-DD0L6u2KAclm2Xh793goElKpeao=
-
 rc@^1.0.1, rc@^1.1.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"


### PR DESCRIPTION
Related to https://github.com/netlify/netlify-identity-widget/pull/300

Could not find a place we're using this dependency.

Searched using `grep -rni --exclude-dir={node_modules,build} "raw-loader" .`