### PR TITLE
feat: Add the ability to clear an invalid site URL

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -63,6 +63,7 @@ class App extends Component {
   handleLogout = () => this.props.store.logout();
   handleSiteURL = (url) => this.props.store.setSiteURL(url);
   clearSiteURL = (url) => this.props.store.clearSiteURL();
+  clearStoreError = () => this.props.store.setError();
   handleExternalLogin = (provider) => this.props.store.externalLogin(provider);
   handleUser = ({ name, email, password }) => {
     const { store } = this.props;
@@ -201,6 +202,9 @@ class App extends Component {
           onClose={this.handleClose}
           logo={store.modal.logo}
           t={store.translate}
+          isLocal={store.isLocal}
+          clearSiteURL={this.clearSiteURL}
+          clearStoreError={this.clearStoreError}
         >
           {this.renderBody()}
           {this.renderProviders()}

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -34,9 +34,13 @@ export default class Modal extends Component {
       isOpen,
       children,
       logo,
-      t
+      t,
+      isLocal,
+      clearSiteURL,
+      clearStoreError
     } = this.props;
     const hidden = loading || !isOpen;
+    const formattedError = error ? formatError(error) : null;
     return (
       <div
         className="modalContainer"
@@ -86,9 +90,22 @@ export default class Modal extends Component {
                 </button>
               </div>
             )}
-            {error && (
+            {formattedError && (
               <div className="flashMessage error">
-                <span>{t(formatError(error))}</span>
+                <span>{t(formattedError)}</span>
+              </div>
+            )}
+            {isLocal && formattedError && formattedError.includes('Failed to load settings from') && (
+              <div>
+                <button
+                  onclick={e => {
+                      clearSiteURL(e);
+                      clearStoreError(null);
+                  }}
+                  className="btnLink forgotPasswordLink"
+                >
+                  {t("site_url_link_text")}
+                </button>
               </div>
             )}
             {children}

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -100,7 +100,7 @@ export default class Modal extends Component {
               formattedError.includes("Failed to load settings from") && (
                 <div>
                   <button
-                    onclick={e => {
+                    onclick={(e) => {
                       clearSiteURL(e);
                       clearStoreError();
                     }}

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -95,19 +95,21 @@ export default class Modal extends Component {
                 <span>{t(formattedError)}</span>
               </div>
             )}
-            {isLocal && formattedError && formattedError.includes('Failed to load settings from') && (
-              <div>
-                <button
-                  onclick={e => {
+            {isLocal &&
+              formattedError &&
+              formattedError.includes("Failed to load settings from") && (
+                <div>
+                  <button
+                    onclick={e => {
                       clearSiteURL(e);
                       clearStoreError(null);
-                  }}
-                  className="btnLink forgotPasswordLink"
-                >
-                  {t("site_url_link_text")}
-                </button>
-              </div>
-            )}
+                    }}
+                    className="btnLink forgotPasswordLink"
+                  >
+                    {t("site_url_link_text")}
+                  </button>
+                </div>
+              )}
             {children}
           </div>
         </div>

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -102,7 +102,7 @@ export default class Modal extends Component {
                   <button
                     onclick={e => {
                       clearSiteURL(e);
-                      clearStoreError(null);
+                      clearStoreError();
                     }}
                     className="btnLink forgotPasswordLink"
                   >


### PR DESCRIPTION
This PR adds the ability to clear an invalid site URL.

While I was going through the [RedwoodJS authentication tutorial](https://redwoodjs.com/tutorial/authentication) I had accidentally entered the wrong Netlify URL. It took me a hot minute to realize I had to remove it from my local storage. I figured it would be nice to have the "Clear localhost URL" button available if this error occurs.

Here's a gif of it in action!

![NetlifyDX](https://user-images.githubusercontent.com/16005567/87216909-c621c000-c2f8-11ea-8eb8-1c24454267a4.gif)
