### PR TITLE
fix: increase input size to avoid mobile zoom

### DIFF
--- a/src/components/modal.css
+++ b/src/components/modal.css
@@ -346,7 +346,7 @@
   background: #fff;
   color: var(--baseColor);
   box-shadow: none;
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 500;
   line-height: 24px;
   transition: box-shadow ease-in-out 0.15s;


### PR DESCRIPTION
on iOS, inputs with font sizes below 16px are automatically zoomed in, which causes issues with page layouts and hides the close button for the widget modal. this change increases the input size to 16px to avoid the zoom on mobile devices

fix #236