### PR TITLE
fix: module example code typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Import or require as usual:
 const netlifyIdentity = require('netlify-identity-widget');
 
 netlifyIdentity.init({
-  container: '#netlify-modal' // defaults to document.body,
+  container: '#netlify-modal', // defaults to document.body
   locale: 'en' // defaults to 'en'
 });
 


### PR DESCRIPTION
Object has missing comma, which is located in comments instead