### PR TITLE
Use shadow DOM instead of an iframe to encapsulate CSS

### DIFF
--- a/src/components/modal.css
+++ b/src/components/modal.css
@@ -53,6 +53,9 @@
   align-items: center;
   z-index: 99999;
 }
+.modalContainer[aria-hidden="true"] {
+  display: none;
+}
 
 .modalContainer::before {
   content: "";
@@ -253,7 +256,6 @@
 .btnClose::before {
   content: "×";
   font-size: 25px;
-  line-height: 9px;
 }
 
 .btnClose:hover,


### PR DESCRIPTION
Fix https://github.com/netlify/netlify-identity-widget/issues/161

The problem: the widget uses an iframe to encapsulate its CSS and prevent leaking it to the projects using the widget (and vice versa). But since the iframe has a `src` attribute with the value `about:blank`, password managers do not work properly (they refuse to set a password without a corresponding url).

The solution: as suggested by this comment https://github.com/netlify/netlify-identity-widget/issues/161#issuecomment-650653017, this commit replaces the iframe by a shadow DOM element, which still encapsulates the modal CSS, but lets password managers do their thing (confirmed on Firefox 84.0.2).