### PR TITLE
Add Update Password feature into to Modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ netlifyIdentity.init({
 netlifyIdentity.open(); // open the modal
 netlifyIdentity.open('login'); // open the modal to the login tab
 netlifyIdentity.open('signup'); // open the modal to the signup tab
+netlifyIdentity.open('updatePassword'); // open the update password modal if the user is logged in
 
 netlifyIdentity.on('init', user => console.log('init', user));
 netlifyIdentity.on('login', user => console.log('login', user));
@@ -158,6 +159,7 @@ module API. Options include:
   APIUrl: 'https://www.example.com/.netlify/functions/identity'; // Absolute url to endpoint.  ONLY USE IN SPECIAL CASES!
   namePlaceholder: 'some-placeholder-for-Name'; // custom placeholder for name input form
   locale: 'en'; // language code for translations - available: en, fr, es, pt, hu - default to en
+  logo: true; // show or hide the Netlify logo
 }
 ```
 

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -36,8 +36,8 @@ const pages = {
     link: "login",
     link_text: "never_mind"
   },
-  recovery: {
-    title: "recover_password",
+  updatePassword: {
+    title: "update_password",
     button: "update_password",
     button_saving: "updating_password",
     password: "new-password",
@@ -81,7 +81,7 @@ class App extends Component {
       case "invite":
         store.acceptInvite(password);
         break;
-      case "recovery":
+      case "updatePassword":
         store.updatePassword(password);
         break;
     }
@@ -104,11 +104,12 @@ class App extends Component {
     if (!store.settings) {
       return;
     }
-    if (store.user) {
+    if (store.user && store.modal.page !== "updatePassword") {
       return (
         <LogoutForm
           user={store.user}
           saving={store.saving}
+          onUpdatePassword={() => this.handlePage("updatePassword")}
           onLogout={this.handleLogout}
           t={store.translate}
         />
@@ -121,7 +122,7 @@ class App extends Component {
     return (
       <div>
         <UserForm
-          page={pages[store.modal.page] || {}}
+          page={page}
           message={store.message}
           saving={store.saving}
           onSubmit={this.handleUser}

--- a/src/components/controls.js
+++ b/src/components/controls.js
@@ -13,6 +13,11 @@ class Controls extends Component {
     this.props.store.openModal("login");
   };
 
+  handleUpdatePassword = (e) => {
+    e.preventDefault();
+    this.props.store.openModal("updatePassword");
+  };
+
   handleLogout = (e) => {
     e.preventDefault();
     this.props.store.openModal("user");
@@ -54,6 +59,15 @@ class Controls extends Component {
               onClick={this.handleLogout}
             >
               {t("log_out")}
+            </a>
+          </li>
+          <li className="netlify-identity-item">
+            <a
+              className="netlify-identity-update-password"
+              href="#"
+              onClick={this.handleUpdatePassword}
+            >
+              {t("update_password")}
             </a>
           </li>
         </ul>

--- a/src/components/forms/logout.js
+++ b/src/components/forms/logout.js
@@ -28,10 +28,7 @@ export default class LogoutForm extends Component {
               user.email}
           </span>
         </p>
-        <button
-          onClick={this.handleUpdatePassword}
-          className={`btn btnProvider`}
-        >
+        <button onClick={this.handleUpdatePassword} className="btn">
           {t("update_password")}
         </button>
         <Button

--- a/src/components/forms/logout.js
+++ b/src/components/forms/logout.js
@@ -2,10 +2,16 @@ import { h, Component } from "preact";
 import Button from "./button";
 
 export default class LogoutForm extends Component {
+  handleUpdatePassword = (e) => {
+    e.preventDefault();
+    this.props.onUpdatePassword();
+  };
+
   handleLogout = (e) => {
     e.preventDefault();
     this.props.onLogout();
   };
+
   render() {
     const { user, saving, t } = this.props;
 
@@ -22,6 +28,12 @@ export default class LogoutForm extends Component {
               user.email}
           </span>
         </p>
+        <button
+          onClick={this.handleUpdatePassword}
+          className={`btn btnProvider`}
+        >
+          {t("update_password")}
+        </button>
         <Button
           saving={saving}
           text={t("log_out")}

--- a/src/components/forms/message.js
+++ b/src/components/forms/message.js
@@ -9,8 +9,12 @@ const messages = {
     type: "success",
     text: "message_password_mail"
   },
+  password_changed: {
+    type: "success",
+    text: "message_password_changed"
+  },
   email_changed: {
-    type: "sucess",
+    type: "success",
     text: "message_email_changed"
   },
   verfication_error: {

--- a/src/foo.ejs
+++ b/src/foo.ejs
@@ -104,13 +104,14 @@
 			display: flex;
 		}
 
-		[data-netlify-identity-menu] li:first-child {
-			margin-right: 16px;
+		[data-netlify-identity-menu] li:last-child {
+			margin-right: 0;
 		}
 
 		[data-netlify-identity-menu] li {
 			list-style-type: none;
 			display: inline-block;
+			margin-right: 16px;
 		}
 
 		[data-netlify-identity-menu] a {

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -104,13 +104,14 @@
 			display: flex;
 		}
 
-		[data-netlify-identity-menu] li:first-child {
-			margin-right: 16px;
+		[data-netlify-identity-menu] li:last-child {
+			margin-right: 0;
 		}
 
 		[data-netlify-identity-menu] li {
 			list-style-type: none;
 			display: inline-block;
+			margin-right: 16px;
 		}
 
 		[data-netlify-identity-menu] a {

--- a/src/netlify-identity.js
+++ b/src/netlify-identity.js
@@ -18,6 +18,7 @@ function trigger(callback) {
 const validActions = {
   login: true,
   signup: true,
+  updatePassword: true,
   error: true
 };
 
@@ -35,12 +36,13 @@ const netlifyIdentity = {
       }
     }
   },
-  open: (action) => {
-    action = action || "login";
+  open: (action = "login") => {
     if (!validActions[action]) {
       throw new Error(`Invalid action for open: ${action}`);
     }
-    store.openModal(store.user ? "user" : action);
+    store.openModal(
+      store.user && action !== "updatePassword" ? "user" : action
+    );
   },
   close: () => {
     store.closeModal();

--- a/src/netlify-identity.test.js
+++ b/src/netlify-identity.test.js
@@ -183,4 +183,66 @@ describe("netlifyIdentity", () => {
       expect(store.gotrue.setCookie).toEqual(false);
     });
   });
+
+  describe("open", () => {
+    it("should invoke open event when called with no arguments", () => {
+      const { default: store } = require("./state/store");
+      const { default: netlifyIdentity } = require("./netlify-identity");
+      store.openModal = jest.fn();
+
+      netlifyIdentity.open();
+
+      expect(store.openModal).toHaveBeenCalledTimes(1);
+      expect(store.openModal).toHaveBeenCalledWith("login");
+    });
+  });
+
+  it("should invoke open event when called with a valid argument", () => {
+    const { default: store } = require("./state/store");
+    const { default: netlifyIdentity } = require("./netlify-identity");
+    store.openModal = jest.fn();
+
+    netlifyIdentity.open("signup");
+
+    expect(store.openModal).toHaveBeenCalledTimes(1);
+    expect(store.openModal).toHaveBeenCalledWith("signup");
+  });
+
+  it("should invoke open event with user if store.user exists", () => {
+    const { default: store } = require("./state/store");
+    const { default: netlifyIdentity } = require("./netlify-identity");
+    store.openModal = jest.fn();
+    store.user = {
+      name: "foo"
+    };
+
+    netlifyIdentity.open();
+
+    expect(store.openModal).toHaveBeenCalledTimes(1);
+    expect(store.openModal).toHaveBeenCalledWith("user");
+  });
+
+  it("should invoke open event with the updatePassword action if store.user exists", () => {
+    const { default: store } = require("./state/store");
+    const { default: netlifyIdentity } = require("./netlify-identity");
+    store.openModal = jest.fn();
+    store.user = {
+      name: "foo"
+    };
+
+    netlifyIdentity.open("updatePassword");
+
+    expect(store.openModal).toHaveBeenCalledTimes(1);
+    expect(store.openModal).toHaveBeenCalledWith("updatePassword");
+  });
+
+  it("should not invoke open event when called with an invalid argument", () => {
+    const { default: store } = require("./state/store");
+    const { default: netlifyIdentity } = require("./netlify-identity");
+    store.openModal = jest.fn();
+
+    const openInvalidAction = () => netlifyIdentity.open("invalid");
+
+    expect(openInvalidAction).toThrow("Invalid action for open: invalid");
+  });
 });

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -168,7 +168,7 @@ store.updatePassword = action(function updatePassword(password) {
     .then((user) => {
       store.user = user;
       store.recovered_user = null;
-      store.modal.page = "user";
+      store.message = "password_changed";
       store.saving = false;
     })
     .catch(store.setError);
@@ -256,7 +256,7 @@ store.verifyToken = action(function verifyToken(type, token) {
         });
       break;
     default:
-      store.error = "Unkown token type";
+      store.error = "Unknown token type";
   }
 });
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -23,6 +23,7 @@
   "site_url_submit": "Set site's URL",
   "message_confirm": "A confirmation message was sent to your email, click the link there to continue.",
   "message_password_mail": "We've sent a recovery email to your account, follow the link there to reset your password.",
+  "message_password_changed": "Your password has been updated!",
   "message_email_changed": "Your email address has been updated!",
   "message_verfication_error": "There was an error verifying your account. Please try again or contact an administrator.",
   "message_signup_disabled": "Public signups are disabled. Contact an administrator and ask for an invite.",


### PR DESCRIPTION
**Background**
Adds support for the Update Password feature, integration with GoTrue was already coded so it was easy enough to hook up to the modal pages.

**This PR will**
- Update docs with `UpdatePassword` changes & `logo` init value
- Logic to show Update Password button on the user modal
- Logic to open the Update Password from the `open` global object
- Add a new translation for when the password is successfully updated
- Added unit tests for `open` logic

**User Modal:**
![image](https://user-images.githubusercontent.com/14197082/115097100-1f6dee00-9f20-11eb-879b-5bffdc297edb.png)

**UpdatePassword Modal:**
![image](https://user-images.githubusercontent.com/14197082/115097084-0cf3b480-9f20-11eb-9bd7-828b3a139fa5.png)

P.S - this is my first contribution here so let me know if I've missed anything or anyone has any better approaches