### PR TITLE
Fixes #408

### DIFF
--- a/example/react/src/App.js
+++ b/example/react/src/App.js
@@ -42,18 +42,18 @@ const netlifyAuth = {
   isAuthenticated: false,
   user: null,
   authenticate(callback) {
-    this.isAuthenticated = true;
     netlifyIdentity.open();
     netlifyIdentity.on('login', user => {
       this.user = user;
+      this.isAuthenticated = true;
       callback(user);
     });
   },
   signout(callback) {
-    this.isAuthenticated = false;
     netlifyIdentity.logout();
     netlifyIdentity.on('logout', () => {
       this.user = null;
+      this.isAuthenticated = false;
       callback();
     });
   }


### PR DESCRIPTION
This PR fixes bug #408 

steps to reproduce
1. click protected link (which opens the netlify login widget)
2. close netlify widget without entering any email or password
3. click protected link again
error throw is:
```
TypeError: Cannot read property 'email' of null
```
These changes fix the above mentioned crash as the auth flags are set in the correct places.