### PR TITLE
fix: remove identity prefix from site URL if exists

### DIFF
--- a/src/components/forms/siteurl.js
+++ b/src/components/forms/siteurl.js
@@ -1,5 +1,18 @@
 import { h, Component } from "preact";
 
+/**
+ * @arg {string} string
+ * @arg {string} ending
+ **/
+function removeFrom(string, mark) {
+  const index = string.indexOf(mark);
+  if (index === -1) {
+    return string;
+  }
+
+  return string.substring(0, string.length - mark.length);
+}
+
 export default class SiteURLForm extends Component {
   constructor(props) {
     super(props);
@@ -12,7 +25,8 @@ export default class SiteURLForm extends Component {
 
   addSiteURL = (e) => {
     e.preventDefault();
-    this.props.onSiteURL(this.state.url);
+    const url = removeFrom(this.state.url, "/.netlify/identity");
+    this.props.onSiteURL(url);
   };
 
   clearSiteURL = (e) => {


### PR DESCRIPTION
When copy pasting the Identity URL from the Netlify Identity tab in the UI, it contains the `/.netlify/identity` path, while the widget expects it without the path.

This PR trims `https://<site-domain>/.netlify/identity` to `https://<site-domain>.netlify.app` to handle that use case.