### PR TITLE
Canceling login in React example still sets authenticated to `true`

### DIFF
--- a/example/react/src/App.js
+++ b/example/react/src/App.js
@@ -42,17 +42,17 @@ const netlifyAuth = {
   isAuthenticated: false,
   user: null,
   authenticate(callback) {
-    this.isAuthenticated = true;
     netlifyIdentity.open();
     netlifyIdentity.on('login', user => {
+      this.isAuthenticated = true;
       this.user = user;
       callback(user);
     });
   },
   signout(callback) {
-    this.isAuthenticated = false;
     netlifyIdentity.logout();
     netlifyIdentity.on('logout', () => {
+      this.isAuthenticated = false;
       this.user = null;
       callback();
     });


### PR DESCRIPTION
Bug: `netlifyAuth.isAuthenticated` is set to `true` before the login is actually complete. This means that if you close the login form without logging in, `netlifyAuth.isAuthenticated` is still set to `true`

Fixes #486 