### PR TITLE
feat: use button element for more semantic markup

### DIFF
--- a/src/components/controls.js
+++ b/src/components/controls.js
@@ -28,13 +28,13 @@ class Controls extends Component {
 
     if (this.props.mode === "button") {
       return (
-        <a
+        <button
+          type="button"
           className="netlify-identity-button"
-          href="#"
           onClick={this.handleButton}
         >
           {this.props.text || (user ? t("log_out") : t("log_in"))}
-        </a>
+        </button>
       );
     }
 
@@ -48,13 +48,13 @@ class Controls extends Component {
             </span>
           </li>
           <li className="netlify-identity-item">
-            <a
+            <button
+              type="button"
               className="netlify-identity-logout"
-              href="#"
               onClick={this.handleLogout}
             >
               {t("log_out")}
-            </a>
+            </button>
           </li>
         </ul>
       );
@@ -63,22 +63,22 @@ class Controls extends Component {
     return (
       <ul className="netlify-identity-menu">
         <li className="netlify-identity-item">
-          <a
+          <button
+            type="button"
             className="netlify-identity-signup"
-            href="#"
             onClick={this.handleSignup}
           >
             {t("sign_up")}
-          </a>
+          </button>
         </li>
         <li className="netlify-identity-item">
-          <a
+          <button
+            type="button"
             className="netlify-identity-login"
-            href="#"
             onClick={this.handleLogin}
           >
             {t("log_in")}
-          </a>
+          </button>
         </li>
       </ul>
     );

--- a/src/components/controls.js
+++ b/src/components/controls.js
@@ -8,18 +8,15 @@ class Controls extends Component {
     this.props.store.openModal("signup");
   };
 
-  handleLogin = (e) => {
-    e.preventDefault();
+  handleLogin = () => {
     this.props.store.openModal("login");
   };
 
-  handleLogout = (e) => {
-    e.preventDefault();
+  handleLogout = () => {
     this.props.store.openModal("user");
   };
 
-  handleButton = (e) => {
-    e.preventDefault();
+  handleButton = () => {
     this.props.store.openModal(this.props.store.user ? "user" : "login");
   };
 

--- a/src/foo.ejs
+++ b/src/foo.ejs
@@ -71,7 +71,7 @@
 			margin-bottom: 8px;
 		}
 
-		[data-netlify-identity-button] a {
+		[data-netlify-identity-button] button {
 		  display: block;
 		  position: relative;
 		  width: 100%;
@@ -94,8 +94,8 @@
 		  white-space: nowrap;
 		}
 
-		[data-netlify-identity-button] a:hover,
-		[data-netlify-identity-button] a:focus {
+		[data-netlify-identity-button] button:hover,
+		[data-netlify-identity-button] button:focus {
 		  background-color: #007a70;
 		  text-decoration: none;
 		}

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -72,7 +72,7 @@
 							margin-bottom: 8px;
 						}
 
-						[data-netlify-identity-button] a {
+						[data-netlify-identity-button] button {
 							display: block;
 							position: relative;
 							width: 100%;
@@ -95,8 +95,8 @@
 							white-space: nowrap;
 						}
 
-						[data-netlify-identity-button] a:hover,
-						[data-netlify-identity-button] a:focus {
+						[data-netlify-identity-button] button:hover,
+						[data-netlify-identity-button] button:focus {
 							background-color: #007a70;
 							text-decoration: none;
 						}
@@ -114,11 +114,11 @@
 							display: inline-block;
 						}
 
-						[data-netlify-identity-menu] a {
+						[data-netlify-identity-menu] button {
 							display: block;
 							position: relative;
 							width: 192px;
-							height: 24px;
+							min-height: 24px;
 							padding: 8px;
 							outline: 0;
 							cursor: pointer;
@@ -135,8 +135,8 @@
 							white-space: nowrap;
 						}
 
-						[data-netlify-identity-menu] a:hover,
-						[data-netlify-identity-menu] a:focus {
+						[data-netlify-identity-menu] button:hover,
+						[data-netlify-identity-menu] button:focus {
 							background-color: #007a70;
 							text-decoration: none;
 						}


### PR DESCRIPTION
Hi 👋 

I noticed the project was using anchors (`<a>`) elements with an `onClick` handler, rather than using `<button>` elements. Generally, a link should be used for taking users to an entirely new page and should have a `href` value other than `#` (unless you are creating a link to scroll a user to the top of the page), whereas a button element should be used for operations that keep the user on the same page but change things, like opening or closing a modal.

By using the right element we improve things like accessibility, as the element can be announced as either a link or a button, and this gives users of assistive technology more information about whether they want to interact with the element, and what they should expect to happen if they do interact with it.

It also means we can remove the `e.preventDefault()` calls from the codebase as there's no default link behaviour to have to prevent.

You can find out a bit more info about this issue here: https://www.htmhell.dev/8-anchor-tag-used-as-button

**Note that this should be considered a breaking change as the change in element could affect existing user's CSS selectors.**
