### PR TITLE
Fix: Potential NPE in refresh()

### DIFF
--- a/src/netlify-identity.js
+++ b/src/netlify-identity.js
@@ -60,8 +60,16 @@ const netlifyIdentity = {
   refresh(force) {
     if (!store.gotrue) {
       store.openModal("login");
+      return Promise.reject(new Error('netlify-identity-widget: gotrue not initialized'))
     }
-    return store.gotrue.currentUser().jwt(force);
+
+    const currentUser = store.gotrue.currentUser()
+
+    if (currentUser) {
+      return currentUser.jwt(force)
+    } else {
+      return Promise.reject(new Error('netlify-identity-widget: no currentUser'));
+    }
   },
   init: (options) => {
     init(options);


### PR DESCRIPTION
If there is no user when calling `refresh()` an exception will be thrown:
`Error: null is not an object (evaluating 'u.default.gotrue.currentUser().jwt')`
A NPE would also have been thrown if gotrue hadn't been initialized (not available in the store).

Looking at the [typings here](https://github.com/netlify/gotrue-js/blob/8cdd79797cdf5f13fc9c5941ab147cd9d30bcfa2/index.d.ts#L24) we can see that `getCurrentUser()` is indeed expected to return `null` sometimes.

I also made `refresh()` always return a promise as [the typings](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/38ffb27cc688981b698a0929d9d3e62d20629889/types/netlify-identity-widget/index.d.ts#L117) says it should. I tried to model it after how [gotrue-js does it](https://github.com/netlify/gotrue-js/blob/8cdd79797cdf5f13fc9c5941ab147cd9d30bcfa2/src/user.js#L65)
