### PR TITLE
Added missing translations for existing user & no found user

### DIFF
--- a/src/translations/cs.json
+++ b/src/translations/cs.json
@@ -37,5 +37,7 @@
   "No user found with this email": "Nebyl nalezen žádný uživatel s tímto e-mailem",
   "Invalid Password": "Neplatné heslo",
   "Email not confirmed": "E-mail nebyl potvrzen",
-  "User not found": "Uživatel nebyl nalezen"
+  "User not found": "Uživatel nebyl nalezen",
+  "A user with this email address has already been registered": "Uživatel s tímto e-mailovým adresou již byl zaregistrován.",
+  "No user found with that email, or password invalid.": "Žádný uživatel s tímto e-mailem nebyl nalezen nebo heslo je neplatné."
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -37,5 +37,7 @@
   "No user found with this email": "No user found with this email",
   "Invalid Password": "Invalid Password",
   "Email not confirmed": "Email not confirmed",
-  "User not found": "User not found"
+  "User not found": "User not found",
+  "A user with this email address has already been registered": "A user with this email address has already been registered",
+  "No user found with that email, or password invalid.": "No user found with that email, or password invalid."
 }

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -37,5 +37,7 @@
   "No user found with this email": "No existe ningún usuario con este correo electrónico",
   "Invalid Password": "La contraseña es invalida",
   "Email not confirmed": "Correo electrónico no confirmado",
-  "User not found": "Usuario no encontrado"
+  "User not found": "Usuario no encontrado",
+  "A user with this email address has already been registered": "Un usuario con este mail ya ha sido registrado.",
+  "No user found with that email, or password invalid.": "Usuario no encontrado con ese mail, o contraseña inválida."
 }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -37,5 +37,7 @@
   "No user found with this email": "Aucun utilisateur trouvé avec cet e-mail",
   "Invalid Password": "Mot de passe incorrect",
   "Email not confirmed": "Adresse e-mail non confirmée",
-  "User not found": "Aucun utilisateur trouvé"
+  "User not found": "Aucun utilisateur trouvé",
+  "A user with this email address has already been registered": "Un utilisateur avec cette adresse e-mail a déjà été enregistré.",
+  "No user found with that email, or password invalid.": "Aucun utilisateur trouvé avec cet e-mail, ou mot de passe invalide."
 }

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -37,5 +37,7 @@
   "No user found with this email": "Nem található fiók ezzel az e-mail címmel",
   "Invalid Password": "Helytelen Jelszó",
   "Email not confirmed": "Az e-mail nem erősült meg",
-  "User not found": "Felhasználó nem található"
+  "User not found": "Felhasználó nem található",
+  "A user with this email address has already been registered": "Egy felhasználó ezzel az e-mail címmel már regisztrált.",
+  "No user found with that email, or password invalid.": "Nem található felhasználó ezzel az e-mail címmel, vagy érvénytelen jelszó."
 }

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -37,5 +37,7 @@
   "No user found with this email": "Nie znaleziono użytkownika o tym adresie",
   "Invalid Password": "Hasło nieprawidłowe",
   "Email not confirmed": "Email nie został potwierdzony",
-  "User not found": "Nie znaleziono użytkownika"
+  "User not found": "Nie znaleziono użytkownika",
+  "A user with this email address has already been registered": "Użytkownik z tym adresem e-mail jest już zarejestrowany.",
+  "No user found with that email, or password invalid.": "Nie znaleziono użytkownika o tym adresie e-mail lub hasło jest nieprawidłowe."
 }

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -37,5 +37,7 @@
   "No user found with this email": "Nenhum usuário encontrado com esse email",
   "Invalid Password": "Senha inválida",
   "Email not confirmed": "Email não confirmado",
-  "User not found": "Usuário não encontrado"
+  "User not found": "Usuário não encontrado",
+  "A user with this email address has already been registered": "Um usuário com este endereço de e-mail já foi registrado.",
+  "No user found with that email, or password invalid.": "Nenhum usuário encontrado com esse e-mail, ou senha inválida."
 }

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -37,5 +37,7 @@
   "Invalid Password": "Неправильный пароль",
   "continue_with": "Продолжить с",
   "Email not confirmed": "Адрес электронной почты не подтверждён",
-  "User not found": "Пользователь не найден"
+  "User not found": "Пользователь не найден",
+  "A user with this email address has already been registered": "Пользователь с этим адресом электронной почты уже зарегистрирован.",
+  "No user found with that email, or password invalid.": "Пользователь с таким адресом электронной почты не найден или неверный пароль."
 }

--- a/src/translations/sk.json
+++ b/src/translations/sk.json
@@ -37,5 +37,7 @@
   "No user found with this email": "Nebol nájdený žiadny užívateľ s týmto e-mailom",
   "Invalid Password": "Neplatné heslo",
   "Email not confirmed": "E-mail nebol potvrdený",
-  "User not found": "Používateľ nebol nájdený"
+  "User not found": "Používateľ nebol nájdený",
+  "A user with this email address has already been registered": "Používateľ s touto e-mailovou adresou už bol zaregistrovaný.",
+  "No user found with that email, or password invalid.": "Žiadny používateľ s týmto e-mailom nebol nájdený, alebo heslo je neplatné."
 }


### PR DESCRIPTION
The original translation files are missing two translations:

- Sign up: an existing user is trying to register
- Log in: an unexisting user is trying to login

Translations were added for all languages supported. 